### PR TITLE
feat: uses unsplash API for dynamic images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ jspm_packages
 
 # OSX crap
 .DS_Store
+
+# dotenv
+.env

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['images.unsplash.com'],
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "14.2.3",
         "next-themes": "^0.3.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "unsplash-js": "^7.0.19"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -5483,6 +5484,14 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "node_modules/unsplash-js": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/unsplash-js/-/unsplash-js-7.0.19.tgz",
+      "integrity": "sha512-j6qT2floy5Q2g2d939FJpwey1yw/GpQecFiSouyJtsHQPj3oqmqq3K4rI+GF8vU1zwGCT7ZwIGQd2dtCQLjYJw==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "14.2.3",
     "next-themes": "^0.3.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "unsplash-js": "^7.0.19"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/api/unsplash/photos/random/route.ts
+++ b/src/app/api/unsplash/photos/random/route.ts
@@ -1,0 +1,58 @@
+import { PairCount, VALID_PAIR_COUNTS } from "@/app/components/settings";
+import { NextResponse } from "next/server";
+import { createApi, Orientation } from "unsplash-js";
+
+const unsplash = createApi({
+  accessKey: process.env.UNSPLASH_ACCESS_KEY!,
+})
+
+const VALID_ORIENTATIONS = ['landscape', 'portrait', 'squarish']
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get('query') || undefined
+  const featured = Boolean(searchParams.get('featured'))
+  const rawCount = searchParams.get('count')
+  const rawOrientation = searchParams.get('orientation') || undefined
+
+  let missingRequiredParams: string[] = []
+
+  let count: number | undefined
+  if (rawCount) {
+    if (!VALID_PAIR_COUNTS.includes(parseInt(rawCount))) {
+      return NextResponse.json({ error: `Invalid count: ${rawCount}. Must be one of: ${VALID_PAIR_COUNTS.join(', ')}` }, { status: 400 })
+    }
+    count = parseInt(rawCount) as PairCount
+  } else {
+    missingRequiredParams.push('count')
+  }
+
+  let orientation: Orientation | undefined
+  if (rawOrientation) {
+    if (!VALID_ORIENTATIONS.includes(rawOrientation)) {
+      return NextResponse.json({ error: `Invalid orientation: ${rawOrientation}. Must be one of: ${VALID_ORIENTATIONS.join(', ')}` }, { status: 400 })
+    }
+    orientation = rawOrientation as Orientation
+  } else {
+    missingRequiredParams.push('orientation')
+  }
+
+  if (missingRequiredParams.length > 0) {
+    return NextResponse.json({ error: `Missing required parameters: ${missingRequiredParams.join(', ')}` }, { status: 400 })
+  }
+
+  const data = await unsplash.photos.getRandom({
+    query,
+    count,
+    orientation,
+    featured,
+  }).catch((error) => {
+    return { errors: [error.message] }
+  })
+
+  if (data.errors) {
+    return NextResponse.json({ error: data.errors }, { status: 500 })
+  }
+
+  return NextResponse.json({ data })
+}

--- a/src/app/components/MemoryCard.tsx
+++ b/src/app/components/MemoryCard.tsx
@@ -24,7 +24,7 @@ export default function MemoryCard({ card, disabled, matchedCards, selectedCards
           <StarFilledIcon />
         </div>
         <div className={styles.cardBack}>
-          <Image src={card.imageUrl} alt={card.key} width="360" height="360" />
+          <Image priority={true} src={card.imageUrl} alt={card.key} width="360" height="360" />
         </div>
       </div>
     </div>

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -1,22 +1,41 @@
-import { Flex, Button, Select } from "@radix-ui/themes"
+import { Flex, Button, Select, Text } from "@radix-ui/themes"
 import Status from "./Status"
+import { Theme } from "./settings";
 
 type Props = {
     isWin: boolean;
     moveCount: number;
     reset: () => void;
     cardCount: number;
+    theme: string;
     setIsNewGameDialogOpen: (value: boolean) => void;
     handleDifficultySelection: (value: string) => void;
+    handleThemeSelection: (value: Theme) => void;
 }
+
+const themes: Theme[] = [
+  "cities",
+  "nature",
+  "travel",
+  "architecture",
+  "textures",
+  "animals",
+  "people",
+  "food",
+  "candy",
+  "sports",
+  "art",
+]
 
 export const Header = ({
     isWin,
     moveCount,
     reset,
     cardCount,
+    theme,
     setIsNewGameDialogOpen,
     handleDifficultySelection,
+    handleThemeSelection,
 }: Props) => {
   return (
     <Flex gap="4" justify="between" align="center">
@@ -33,17 +52,30 @@ export const Header = ({
             </Button>
           )}
         </Flex>
-        <Flex align="center" gap="2">
-          <>Difficulty</>
-          <Select.Root defaultValue="12" value={cardCount.toString()} onValueChange={(value) => handleDifficultySelection(value)}>
-            <Select.Trigger variant="surface" color="blue" />
-            <Select.Content  position="popper">
-              <Select.Item value="12">Easy (4x3)</Select.Item>
-              <Select.Item value="16">Casual (4x4)</Select.Item>
-              <Select.Item value="20">Challenging (5x4)</Select.Item>
-              <Select.Item value="36">Hard (6x6)</Select.Item>
-            </Select.Content>
-          </Select.Root>
+        <Flex gap="4">
+          <Flex align="center" gap="2">
+            <Text size="2">Difficulty</Text>
+            <Select.Root defaultValue="12" value={cardCount.toString()} onValueChange={(value) => handleDifficultySelection(value)}>
+              <Select.Trigger variant="surface" color="blue" />
+              <Select.Content  position="popper">
+                <Select.Item value="12">Easy (4x3)</Select.Item>
+                <Select.Item value="16">Casual (4x4)</Select.Item>
+                <Select.Item value="20">Challenging (5x4)</Select.Item>
+                <Select.Item value="36">Hard (6x6)</Select.Item>
+              </Select.Content>
+            </Select.Root>
+          </Flex>
+          <Flex align="center" gap="2">
+            <Text size="2">Theme</Text>
+            <Select.Root defaultValue="cities" value={theme} onValueChange={(value: Theme) => handleThemeSelection(value)}>
+              <Select.Trigger variant="surface" color="blue" />
+              <Select.Content  position="popper">
+                {themes.map((theme) => (
+                  <Select.Item key={theme} value={theme}>{theme}</Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Flex>
         </Flex>
       </Flex>
   )

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -53,7 +53,7 @@ export const Header = ({
           )}
         </Flex>
         <Flex gap="4">
-          <Flex align="center" gap="2">
+          <Flex direction="column">
             <Text size="2">Difficulty</Text>
             <Select.Root defaultValue="12" value={cardCount.toString()} onValueChange={(value) => handleDifficultySelection(value)}>
               <Select.Trigger variant="surface" color="blue" />
@@ -65,7 +65,7 @@ export const Header = ({
               </Select.Content>
             </Select.Root>
           </Flex>
-          <Flex align="center" gap="2">
+          <Flex direction="column">
             <Text size="2">Theme</Text>
             <Select.Root defaultValue="cities" value={theme} onValueChange={(value: Theme) => handleThemeSelection(value)}>
               <Select.Trigger variant="surface" color="blue" />

--- a/src/app/components/settings.ts
+++ b/src/app/components/settings.ts
@@ -1,18 +1,32 @@
+import { Orientation } from "unsplash-js";
+
+// 4x3, 4x4, 5x4, 6x6 grid sizes
+export const VALID_PAIR_COUNTS = [6, 8, 10, 18]
+export type PairCount = 6 | 8 | 10 | 18;
+
+export type Theme = "cities" | "nature" | "travel" | "architecture" | "textures" | "animals" | "people" | "food" | "candy" | "sports" | "art";
+
 export type Settings = {
-  pairCount: 6 | 8 | 10 | 18; // 4x3, 4x4, 5x4, 6x6 grid sizes
   clearSelectionTimer: number;
+  pairCount: PairCount;
+  theme: Theme;
+  orientation: Orientation;
 }
 
-export const defaultSettings: Settings = { pairCount: 6, clearSelectionTimer: 2000 }
+export const defaultSettings: Settings = {
+  clearSelectionTimer: 2000,
+  pairCount: 6,
+  theme: "cities",
+  orientation: "landscape",
+}
 
 export function loadSettings(): Settings {
   if (typeof localStorage !== 'undefined') {
-    console.log('loading settings from localStorage')
     const savedSettingsJSON = localStorage.getItem('memory-game-settings')
     if (savedSettingsJSON) {
-      console.log('loaded settings:', savedSettingsJSON)
       // TODO: add zod for runtime validation
-      return JSON.parse(savedSettingsJSON)
+      const savedSettings = JSON.parse(savedSettingsJSON)
+      return {...defaultSettings, ...savedSettings}
     }
   }
 
@@ -21,8 +35,6 @@ export function loadSettings(): Settings {
 
 export function saveSettings(settings: Settings) {
   if (typeof localStorage !== 'undefined') {
-    console.log('saving settings to localStorage')
     localStorage.setItem('memory-game-settings', JSON.stringify(settings))
-    console.log('saved settings:', loadSettings())
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,7 @@ export default function Home() {
           "Accept": "application/json",
           "Content-Type": "application/json",
         },
+        cache: "force-cache",
       },
     )
 

--- a/src/lib/getPhotoUrls.ts
+++ b/src/lib/getPhotoUrls.ts
@@ -1,0 +1,43 @@
+import { Random } from "unsplash-js/dist/methods/photos/types"
+
+type GetPhotoUrlParams = {
+  count: number,
+  query: string,
+  orientation: string,
+}
+
+export const getPhotoUrls = async ({ count, query, orientation }: GetPhotoUrlParams) => {
+  const params = new URLSearchParams({
+    count: count.toString(),
+    query,
+    orientation,
+    featured: "true",
+  })
+  const unsplashProxyUrl = new URL(`/api/unsplash/photos/random?${params.toString()}`, window.location.origin)
+  const response = await fetch(
+    unsplashProxyUrl,
+    {
+      method: "GET",
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+      cache: "force-cache",
+    },
+  )
+
+  if (response.ok) {
+    const data = await response.json()
+    if (data.error) {
+      console.error(data.error)
+      return
+    }
+
+    return data.data.response.map((photo: Random) => photo.urls.regular)
+  } else {
+    // TODO: implement toast notification with error message
+    console.error(response.statusText)
+  }
+
+  return []
+}


### PR DESCRIPTION
TODO:

- add server-side caching to `/api/unsplash/photos/random` endpoint to ensure absolute minimum requests to Unsplash API which aggressively rate limits API calls
- add Toast notifications when an error occurs and it must fallback to static images
- add Unsplash and photographer attributions